### PR TITLE
build: fix missing include of ctype.h

### DIFF
--- a/shared.cpp
+++ b/shared.cpp
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <string.h>
 #include <limits.h>


### PR DESCRIPTION
Vanilla repository doesn't build on my Gentoo with GCC 12. 
```
c++ -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=1 -lpcap -lpthread -lssl -lcrypto main.cpp -o tunnel
In file included from factory.cpp:2,
                 from main.cpp:1:
shared.cpp: In function ‘int parse_protocol_tag(char*)’:
shared.cpp:364:14: error: ‘tolower’ was not declared in this scope
  364 |         *c = tolower(*c);
      |              ^~~~~~~
```

This pull request add the missing include of ctype.h :)