### PR TITLE
Pcap optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
-#CXXFLAGS = -ggdb -fsanitize=address -fno-omit-frame-pointer -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=1 -lpcap -lpthread -lssl -lcrypto -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib
-CXXFLAGS = -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=1 -lpcap -lpthread -lssl -lcrypto
+HAVE_PCAP := 1
+USE_ICMP := 1
+
+# Currently building with ICMP support requries PCAP
+ifeq ($(HAVE_PCAP),1)
+	LIBPCAP := -lpcap
+else
+	override USE_ICMP := 0
+endif
+
+#CXXFLAGS = -ggdb -fsanitize=address -fno-omit-frame-pointer -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=$(HAVE_PCAP) -DUSE_ICMP=$(USE_ICMP) -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib
+CXXFLAGS = -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=$(HAVE_PCAP) -DUSE_ICMP=$(USE_ICMP)
+LIBS = $(LIBPCAP) -lpthread -lssl -lcrypto
 
 tunnel: main.cpp shared.cpp factory.cpp forwarders.cpp tls_helpers.cpp transport_base.cpp obfuscate_base.cpp simple_obfuscator.cpp xor_obfuscator.cpp mocker_base.cpp dns_mocker.cpp http_ws_mocker.cpp socks5_proxy.cpp udp_base.cpp udp_client.cpp udp_server.cpp dtls_server.cpp tcp_base.cpp tcp_client.cpp tcp_server.cpp icmp_base.cpp icmp_client.cpp icmp_server.cpp icmp6_base.cpp icmp6_client.cpp icmp6_server.cpp
-	$(CXX) $(CXXFLAGS) main.cpp -o $@
+	$(CXX) $(CXXFLAGS) main.cpp -o $@ $(LIBS)
 
 clean:
 	rm tunnel
+.phony: clean

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ HAVE_PCAP := 1
 USE_ICMP := 1
 
 # Currently the only reason for PCAP is ICMP
-ifeq ($(HAVE_PCAP),1)
-	LIBPCAP := -lpcap
-endif
 ifneq ($(USE_ICMP),1)
 	override HAVE_PCAP := 0
+	ifeq ($(HAVE_PCAP),1)
+		LIBPCAP := -lpcap
+	endif
 endif
 
 #CXXFLAGS = -ggdb -fsanitize=address -fno-omit-frame-pointer -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=$(HAVE_PCAP) -DUSE_ICMP=$(USE_ICMP) -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 HAVE_PCAP := 1
 USE_ICMP := 1
 
-# Currently building with ICMP support requries PCAP
+# Currently the only reason for PCAP is ICMP
 ifeq ($(HAVE_PCAP),1)
 	LIBPCAP := -lpcap
-else
-	override USE_ICMP := 0
+endif
+ifneq ($(USE_ICMP),1)
+	override HAVE_PCAP := 0
 endif
 
 #CXXFLAGS = -ggdb -fsanitize=address -fno-omit-frame-pointer -std=c++14 -Wall -Wextra -Ofast -DHAVE_PCAP=$(HAVE_PCAP) -DUSE_ICMP=$(USE_ICMP) -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib

--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ make
 If you wish to build without libpcap:
 
 * Skip the installation of the `libpcap` dependency.
-* Open the `Makefile` file in your editor,
-* Find the `CXXFLAGS` line (should be the first),
-* Replace the flags `-DHAVE_PCAP=1 -lpcap` with `-DHAVE_PCAP=0`
+* `make HAVE_PCAP=0`
 
 ## Tunneling VPN traffic
 

--- a/factory.cpp
+++ b/factory.cpp
@@ -6,7 +6,7 @@
 #include "dtls_server.cpp"
 #include "tcp_client.cpp"
 #include "tcp_server.cpp"
-#if HAVE_PCAP
+#if USE_ICMP
 #include "icmp_client.cpp"
 #include "icmp_server.cpp"
 #include "icmp6_client.cpp"
@@ -49,20 +49,20 @@ transport_base* create_transport(int protocol, struct sockaddr_in *address, bool
 #endif
 
         case PROTO_ICMP:
-#if HAVE_PCAP
+#if USE_ICMP
             if (server) return new icmp_server(*address, session);
             else        return new icmp_client(*address, session);
 #else
-            fprintf(stderr, "This version was not compiled with PCAP support.\n");
+            fprintf(stderr, "This version was not compiled with ICMP support.\n");
             return nullptr;
 #endif
 
         case PROTO_ICMP6:
-#if HAVE_PCAP
+#if USE_ICMP
             if (server) return new icmp6_server(*(struct sockaddr_in6*)address, session);
             else        return new icmp6_client(*(struct sockaddr_in6*)address, session);
 #else
-            fprintf(stderr, "This version was not compiled with PCAP support.\n");
+            fprintf(stderr, "This version was not compiled with ICMP support.\n");
             return nullptr;
 #endif
         

--- a/factory.cpp
+++ b/factory.cpp
@@ -6,10 +6,12 @@
 #include "dtls_server.cpp"
 #include "tcp_client.cpp"
 #include "tcp_server.cpp"
+#if HAVE_PCAP
 #include "icmp_client.cpp"
 #include "icmp_server.cpp"
 #include "icmp6_client.cpp"
 #include "icmp6_server.cpp"
+#endif
 #include "simple_obfuscator.cpp"
 #include "xor_obfuscator.cpp"
 #include "dns_mocker.cpp"
@@ -47,12 +49,22 @@ transport_base* create_transport(int protocol, struct sockaddr_in *address, bool
 #endif
 
         case PROTO_ICMP:
+#if HAVE_PCAP
             if (server) return new icmp_server(*address, session);
             else        return new icmp_client(*address, session);
+#else
+            fprintf(stderr, "This version was not compiled with PCAP support.\n");
+            return nullptr;
+#endif
 
         case PROTO_ICMP6:
+#if HAVE_PCAP
             if (server) return new icmp6_server(*(struct sockaddr_in6*)address, session);
             else        return new icmp6_client(*(struct sockaddr_in6*)address, session);
+#else
+            fprintf(stderr, "This version was not compiled with PCAP support.\n");
+            return nullptr;
+#endif
         
         default:
             fprintf(stderr, "Protocol %d is not supported.\n", protocol);

--- a/icmp6_client.cpp
+++ b/icmp6_client.cpp
@@ -16,10 +16,12 @@ private:
 #endif
 
 public:
+#if HAVE_PCAP
     icmp6_client(struct sockaddr_in6 remote_addr, struct session* session)
         : transport_base(session->verbose), icmp6_base(session->pcap), pcap(session->pcap), cap_dev(session->cap_dev), remote_addr(remote_addr)
     {
     }
+#endif
 
     icmp6_client(struct sockaddr_in6 remote_addr, bool pcap = false, char *cap_dev = NULL, bool random_id = false, bool verbose = false)
         : transport_base(verbose), icmp6_base(random_id), pcap(pcap), cap_dev(cap_dev), remote_addr(remote_addr)

--- a/icmp6_server.cpp
+++ b/icmp6_server.cpp
@@ -16,10 +16,12 @@ private:
 #endif
 
 public:
+#if HAVE_PCAP
     icmp6_server(struct sockaddr_in6 local_addr, struct session* session)
         : transport_base(session->verbose), icmp6_base(session->random_id), pcap(session->pcap), cap_dev(session->cap_dev), local_addr(local_addr)
     {
     }
+#endif
 
     icmp6_server(struct sockaddr_in6 local_addr, bool pcap = false, char *cap_dev = NULL, bool random_id = false, bool verbose = false)
         : transport_base(verbose), icmp6_base(random_id), pcap(pcap), cap_dev(cap_dev), local_addr(local_addr)

--- a/icmp_client.cpp
+++ b/icmp_client.cpp
@@ -16,10 +16,12 @@ private:
 #endif
 
 public:
+#if HAVE_PCAP
     icmp_client(struct sockaddr_in remote_addr, struct session* session)
         : transport_base(session->verbose), icmp_base(session->random_id), pcap(session->pcap), cap_dev(session->cap_dev), remote_addr(remote_addr)
     {
     }
+#endif
 
     icmp_client(struct sockaddr_in remote_addr, bool pcap = false, char *cap_dev = NULL, bool random_id = false, bool verbose = false)
         : transport_base(verbose), icmp_base(random_id), pcap(pcap), cap_dev(cap_dev), remote_addr(remote_addr)

--- a/icmp_server.cpp
+++ b/icmp_server.cpp
@@ -16,10 +16,12 @@ private:
 #endif
 
 public:
+#if HAVE_PCAP
     icmp_server(struct sockaddr_in local_addr, struct session* session)
         : transport_base(session->verbose), icmp_base(session->random_id), pcap(session->pcap), cap_dev(session->cap_dev), local_addr(local_addr)
     {
     }
+#endif
 
     icmp_server(struct sockaddr_in local_addr, bool pcap = false, char *cap_dev = NULL, bool random_id = false, bool verbose = false)
         : transport_base(verbose), icmp_base(random_id), pcap(pcap), cap_dev(cap_dev), local_addr(local_addr)

--- a/shared.cpp
+++ b/shared.cpp
@@ -342,11 +342,11 @@ void print_help(char* argv[])
     printf("   -h, --help\tDisplays this message.\n");
     printf("\nTCP-specific arguments:\n\n");
     printf("   -e\t\tType of encoding to use for the length header:\n   \t\t  v - 7-bit encoded variable-length header (Default)\n   \t\t  s - 2-byte unsigned short\n   \t\t  n - None (Not recommended)\n");
-    printf("\nICMP/ICMPv6-specific arguments:\n\n");
 #if HAVE_PCAP
+    printf("\nICMP/ICMPv6-specific arguments:\n\n");
     printf("   -p [if]\tUse PCAP for inbound, highly recommended.\n   \t\t  Optional value, defaults to default gateway otherwise.\n");
-#endif
     printf("   -x\t\tExpect identifier and sequence randomization.\n   \t\t  Not recommended, see documentation for pros and cons.\n");
+#endif
     printf("\nDNS-specific arguments:\n\n");
     printf("   -f\t\tBase32-encode data and fragment labels on 60-byte boundaries.\n");
     printf("   -d domain\tOptional domain name to act as the authoritative resolver for.\n");

--- a/shared.cpp
+++ b/shared.cpp
@@ -28,6 +28,9 @@
 #ifndef HAVE_PCAP
     #define HAVE_PCAP 1
 #endif
+#ifndef USE_ICMP
+    #define USE_ICMP 1
+#endif
 #ifndef HAVE_TLS
     #define HAVE_TLS 1
 #endif
@@ -332,7 +335,11 @@ int resolve_host6(const char *addr, struct sockaddr_in6 *sockaddr)
 void print_help(char* argv[])
 {
     printf("usage: %s -l proto:addr:port -r proto:addr:port [args]\narguments:\n\n", argv[0]);
+#if USE_ICMP
     printf("   -l endpoint\tLocal listening protocol, address and port.\n   \t\t  Example: tcp:127.0.0.1:80 / icmp6:[::1]\n   \t\t  Supported protocols: udp, dtls, tcp, tls, icmp, imcp6.\n");
+#else
+    printf("   -l endpoint\tLocal listening protocol, address and port.\n   \t\t  Example: tcp:127.0.0.1:80\n   \t\t  Supported protocols: udp, dtls, tcp, tls.\n");
+#endif
     printf("   -r endpoint\tRemote host to tunnel packets to.\n");
     printf("   -o [mode]\tEnable packet obfuscation. Possible values:\n   \t\t  header - Simple generic header obfuscation (Default)\n   \t\t  xor - XOR packet obfuscation with rolling key\n");
     printf("   -k key\tSpecifies a key for the obfuscator module.\n");
@@ -342,9 +349,11 @@ void print_help(char* argv[])
     printf("   -h, --help\tDisplays this message.\n");
     printf("\nTCP-specific arguments:\n\n");
     printf("   -e\t\tType of encoding to use for the length header:\n   \t\t  v - 7-bit encoded variable-length header (Default)\n   \t\t  s - 2-byte unsigned short\n   \t\t  n - None (Not recommended)\n");
-#if HAVE_PCAP
+#if USE_ICMP
     printf("\nICMP/ICMPv6-specific arguments:\n\n");
+#if HAVE_PCAP
     printf("   -p [if]\tUse PCAP for inbound, highly recommended.\n   \t\t  Optional value, defaults to default gateway otherwise.\n");
+#endif
     printf("   -x\t\tExpect identifier and sequence randomization.\n   \t\t  Not recommended, see documentation for pros and cons.\n");
 #endif
     printf("\nDNS-specific arguments:\n\n");


### PR DESCRIPTION
This restores the ability to build without `libpcap` and allows doing so without editing the `Makefile`, simply `make HAVE_PCAP=0`. 

This patch also permits building without ICMP support (using `make USE_ICMP=0`) for use in an environment where root is not possible.

This addresses the other concern raised in issue #1 